### PR TITLE
chore: pin testdouble to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "npm-run-all": "^4.0.2",
     "nyc": "^11.0.2",
     "tap-spec": "^4.1.1",
-    "testdouble": "^3.0.0"
+    "testdouble": "3.1.1"
   },
   "engines": {
     "node": ">=4",


### PR DESCRIPTION
Issued raised with test double:

https://github.com/testdouble/testdouble.js/issues/270